### PR TITLE
impl Error for ScgiError

### DIFF
--- a/src/scgi.rs
+++ b/src/scgi.rs
@@ -37,6 +37,19 @@ impl Display for ScgiError {
   fn fmt (&self, fmt: &mut Formatter) -> Result<(), std::fmt::Error> {write! (fmt, "{:?}", self)}
 }
 
+impl std::error::Error for ScgiError {
+    fn description(&self) -> &str {
+        "ScgiError"
+    }
+    fn cause(&self) -> Option<&std::error::Error> {
+        match *self {
+            Utf8(ref e) => Some(e),
+            IO(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 /// Read the headers from the stream.
 ///
 /// Returns the vector containing the headers and the `tcp_stream` wrapped into a `BufferedStream`.<br>


### PR DESCRIPTION
So we can use Box\<Error\>.
And because according to https://doc.rust-lang.org/book/error-handling.html#the-error-trait:
"This trait is super generic because it is meant to be implemented for all types that represent errors."

But I'm noob and I do rust for few days only.